### PR TITLE
chore: remove license headers from 23 files

### DIFF
--- a/app/src/main/java/br/com/rbrthmn/ComFin.kt
+++ b/app/src/main/java/br/com/rbrthmn/ComFin.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn
 
 import android.app.Application

--- a/app/src/main/java/br/com/rbrthmn/ui/financialcompanion/ComFinApp.kt
+++ b/app/src/main/java/br/com/rbrthmn/ui/financialcompanion/ComFinApp.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.ui.financialcompanion
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/br/com/rbrthmn/ui/financialcompanion/navigation/ComFinNavGraph.kt
+++ b/app/src/main/java/br/com/rbrthmn/ui/financialcompanion/navigation/ComFinNavGraph.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.ui.financialcompanion.navigation
 
 import androidx.compose.runtime.Composable

--- a/core/ui/src/main/java/br/com/rbrthmn/ui/components/MonthSelectionTopBar.kt
+++ b/core/ui/src/main/java/br/com/rbrthmn/ui/components/MonthSelectionTopBar.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.ui.components
 
 import androidx.compose.foundation.clickable

--- a/core/ui/src/main/res/values/dimens.xml
+++ b/core/ui/src/main/res/values/dimens.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (C) 2022 The Android Open Source Project
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Modifications made by Roberto Kenzo Hamano, 2024
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="padding_extra_small">4dp</dimen>
     <dimen name="padding_small">8dp</dimen>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (C) 2022 The Android Open Source Project
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Modifications made by Roberto Kenzo Hamano, 2024
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="blank" />
     <string name="understood_button">Entendi</string>

--- a/data/common/src/main/java/br/com/rbrthmn/data/DatabaseSeeder.kt
+++ b/data/common/src/main/java/br/com/rbrthmn/data/DatabaseSeeder.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.data
 
 import br.com.rbrthmn.data.db.ComFinDatabase

--- a/data/operations/src/main/java/br/com/rbrthmn/data/operations/local/LocalOperationsDataSource.kt
+++ b/data/operations/src/main/java/br/com/rbrthmn/data/operations/local/LocalOperationsDataSource.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.data.operations.local
 
 import br.com.rbrthmn.data.dao.BankAccountDao

--- a/feature/misc/src/androidTest/java/br/com/rbrthmn/misc/IncomeDivisionsScreenUITest.kt
+++ b/feature/misc/src/androidTest/java/br/com/rbrthmn/misc/IncomeDivisionsScreenUITest.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.misc
 
 import androidx.activity.ComponentActivity

--- a/feature/misc/src/main/java/br/com/rbrthmn/misc/ui/morefeatures/MoreFeaturesScreen.kt
+++ b/feature/misc/src/main/java/br/com/rbrthmn/misc/ui/morefeatures/MoreFeaturesScreen.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.misc.morefeatures
 
 import androidx.compose.foundation.layout.Arrangement

--- a/feature/misc/src/main/java/br/com/rbrthmn/misc/ui/recurringexpenses/RecurringExpense.kt
+++ b/feature/misc/src/main/java/br/com/rbrthmn/misc/ui/recurringexpenses/RecurringExpense.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.misc.recurringexpenses
 
 data class RecurringExpense(

--- a/feature/misc/src/main/java/br/com/rbrthmn/misc/ui/reserves/Reserve.kt
+++ b/feature/misc/src/main/java/br/com/rbrthmn/misc/ui/reserves/Reserve.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.misc.reserves
 
 data class Reserve(

--- a/feature/misc/src/main/java/br/com/rbrthmn/misc/ui/reserves/ReserveOperation.kt
+++ b/feature/misc/src/main/java/br/com/rbrthmn/misc/ui/reserves/ReserveOperation.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.misc.reserves
 
 data class ReserveOperation(

--- a/feature/misc/src/main/java/br/com/rbrthmn/misc/ui/reserves/ReservesScreen.kt
+++ b/feature/misc/src/main/java/br/com/rbrthmn/misc/ui/reserves/ReservesScreen.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.misc.reserves
 
 import androidx.compose.animation.animateContentSize

--- a/feature/operations/src/androidTest/java/br/com/rbrthmn/operations/DatePickerFieldUITest.kt
+++ b/feature/operations/src/androidTest/java/br/com/rbrthmn/operations/DatePickerFieldUITest.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.operations
 
 import androidx.activity.ComponentActivity

--- a/feature/operations/src/main/java/br/com/rbrthmn/operations/di/OperationsModule.kt
+++ b/feature/operations/src/main/java/br/com/rbrthmn/operations/di/OperationsModule.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.operations.di
 
 import br.com.rbrthmn.data.operations.repository.OperationsRepository

--- a/feature/operations/src/main/java/br/com/rbrthmn/operations/ui/OperationsScreen.kt
+++ b/feature/operations/src/main/java/br/com/rbrthmn/operations/ui/OperationsScreen.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.operations.ui
 
 import android.annotation.SuppressLint

--- a/feature/operations/src/main/java/br/com/rbrthmn/operations/ui/OperationsScreenUiState.kt
+++ b/feature/operations/src/main/java/br/com/rbrthmn/operations/ui/OperationsScreenUiState.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.operations.ui
 
 import androidx.compose.runtime.Composable

--- a/feature/operations/src/main/java/br/com/rbrthmn/operations/ui/OperationsScreenViewModel.kt
+++ b/feature/operations/src/main/java/br/com/rbrthmn/operations/ui/OperationsScreenViewModel.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.operations.ui
 
 import androidx.annotation.VisibleForTesting

--- a/feature/operations/src/main/java/br/com/rbrthmn/operations/ui/components/DatePickerField.kt
+++ b/feature/operations/src/main/java/br/com/rbrthmn/operations/ui/components/DatePickerField.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.operations.ui.components
 
 import androidx.compose.foundation.layout.Box

--- a/feature/operations/src/main/java/br/com/rbrthmn/operations/ui/components/OperationsListCard.kt
+++ b/feature/operations/src/main/java/br/com/rbrthmn/operations/ui/components/OperationsListCard.kt
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Modifications made by Roberto Kenzo Hamano, 2024
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package br.com.rbrthmn.operations.ui.components
 
 import android.annotation.SuppressLint

--- a/feature/operations/src/main/res/values/dimens.xml
+++ b/feature/operations/src/main/res/values/dimens.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (C) 2022 The Android Open Source Project
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Modifications made by Roberto Kenzo Hamano, 2024
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="date_picker_field_height">64dp</dimen>
     <dimen name="date_picker_popup_offset">64dp</dimen>

--- a/feature/operations/src/main/res/values/strings.xml
+++ b/feature/operations/src/main/res/values/strings.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (C) 2022 The Android Open Source Project
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Modifications made by Roberto Kenzo Hamano, 2024
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="operations_route">operations</string>
     <string name="balance_title">Balanço</string>


### PR DESCRIPTION
## Summary
- Removes license header comment blocks from 23 files across `app/`, `core/ui/`, `data/common/`, `data/operations/`, `feature/misc/`, and `feature/operations/`
- Pure deletion — no logic changes

Closes #64

## Test plan
- [x] Build passes (`./gradlew assembleDebug`)
- [ ] Unit tests pass (`./gradlew testDebugUnitTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)