### PR TITLE
refactor(specs): state business rules only in behaviors

### DIFF
--- a/feature/auth/src/test/java/br/com/rbrthmn/auth/PasswordRecoveryScreenViewModelTest.kt
+++ b/feature/auth/src/test/java/br/com/rbrthmn/auth/PasswordRecoveryScreenViewModelTest.kt
@@ -55,7 +55,6 @@ class PasswordRecoveryScreenViewModelTest {
     fun `onEmailChange with invalid email should mark email invalid`() {
         viewModel.onIntent(PasswordRecoveryScreenContract.Intent.OnEmailChange(INVALID_EMAIL))
 
-        assertEquals(INVALID_EMAIL, viewModel.uiState.value.email)
         assertFalse(viewModel.uiState.value.isEmailValid)
     }
 
@@ -141,7 +140,7 @@ class PasswordRecoveryScreenViewModelTest {
         }
 
     @Test
-    fun `onResetPasswordClick with invalid fields should not call repository`() {
+    fun `onResetPasswordClick with invalid fields should not attempt password reset`() {
         viewModel.onIntent(
             PasswordRecoveryScreenContract.Intent.OnNewPasswordChange(VALID_PASSWORD)
         )

--- a/feature/auth/src/test/java/br/com/rbrthmn/auth/SignInScreenViewModelTest.kt
+++ b/feature/auth/src/test/java/br/com/rbrthmn/auth/SignInScreenViewModelTest.kt
@@ -52,7 +52,6 @@ class SignInScreenViewModelTest {
     fun `onEmailChange with invalid email should mark email invalid`() {
         viewModel.onIntent(SignInScreenContract.Intent.OnEmailChange(INVALID_EMAIL))
 
-        assertEquals(INVALID_EMAIL, viewModel.uiState.value.email)
         assertFalse(viewModel.uiState.value.isEmailValid)
     }
 
@@ -60,7 +59,6 @@ class SignInScreenViewModelTest {
     fun `onEmailChange with valid email should mark email valid`() {
         viewModel.onIntent(SignInScreenContract.Intent.OnEmailChange(VALID_EMAIL))
 
-        assertEquals(VALID_EMAIL, viewModel.uiState.value.email)
         assertTrue(viewModel.uiState.value.isEmailValid)
     }
 
@@ -68,7 +66,6 @@ class SignInScreenViewModelTest {
     fun `onPasswordChange with blank value should mark password invalid`() {
         viewModel.onIntent(SignInScreenContract.Intent.OnPasswordChange(BLANK_STRING))
 
-        assertEquals(BLANK_STRING, viewModel.uiState.value.password)
         assertFalse(viewModel.uiState.value.isPasswordValid)
     }
 
@@ -76,12 +73,11 @@ class SignInScreenViewModelTest {
     fun `onPasswordChange with value should mark password valid`() {
         viewModel.onIntent(SignInScreenContract.Intent.OnPasswordChange(VALID_PASSWORD))
 
-        assertEquals(VALID_PASSWORD, viewModel.uiState.value.password)
         assertTrue(viewModel.uiState.value.isPasswordValid)
     }
 
     @Test
-    fun `onSignInClick with invalid fields should not call repository`() {
+    fun `onSignInClick with invalid fields should not attempt sign in`() {
         viewModel.onIntent(SignInScreenContract.Intent.OnSignInClick)
 
         coVerify(exactly = 0) { authRepository.signIn(any(), any()) }

--- a/feature/auth/src/test/java/br/com/rbrthmn/auth/SignUpScreenViewModelTest.kt
+++ b/feature/auth/src/test/java/br/com/rbrthmn/auth/SignUpScreenViewModelTest.kt
@@ -52,7 +52,6 @@ class SignUpScreenViewModelTest {
     fun `onNameChange with blank value should mark name invalid`() {
         viewModel.onIntent(SignUpScreenContract.Intent.OnNameChange(BLANK_STRING))
 
-        assertEquals(BLANK_STRING, viewModel.uiState.value.name)
         assertFalse(viewModel.uiState.value.isNameValid)
     }
 
@@ -60,7 +59,6 @@ class SignUpScreenViewModelTest {
     fun `onNameChange with value should mark name valid`() {
         viewModel.onIntent(SignUpScreenContract.Intent.OnNameChange(VALID_NAME))
 
-        assertEquals(VALID_NAME, viewModel.uiState.value.name)
         assertTrue(viewModel.uiState.value.isNameValid)
     }
 
@@ -68,7 +66,6 @@ class SignUpScreenViewModelTest {
     fun `onEmailChange with invalid email should mark email invalid`() {
         viewModel.onIntent(SignUpScreenContract.Intent.OnEmailChange(INVALID_EMAIL))
 
-        assertEquals(INVALID_EMAIL, viewModel.uiState.value.email)
         assertFalse(viewModel.uiState.value.isEmailValid)
     }
 
@@ -76,7 +73,6 @@ class SignUpScreenViewModelTest {
     fun `onEmailChange with valid email should mark email valid`() {
         viewModel.onIntent(SignUpScreenContract.Intent.OnEmailChange(VALID_EMAIL))
 
-        assertEquals(VALID_EMAIL, viewModel.uiState.value.email)
         assertTrue(viewModel.uiState.value.isEmailValid)
     }
 
@@ -84,7 +80,6 @@ class SignUpScreenViewModelTest {
     fun `onPasswordChange with short password should mark password invalid`() {
         viewModel.onIntent(SignUpScreenContract.Intent.OnPasswordChange(SHORT_PASSWORD))
 
-        assertEquals(SHORT_PASSWORD, viewModel.uiState.value.password)
         assertFalse(viewModel.uiState.value.isPasswordValid)
     }
 
@@ -92,7 +87,6 @@ class SignUpScreenViewModelTest {
     fun `onPasswordChange with valid password should mark password valid`() {
         viewModel.onIntent(SignUpScreenContract.Intent.OnPasswordChange(VALID_PASSWORD))
 
-        assertEquals(VALID_PASSWORD, viewModel.uiState.value.password)
         assertTrue(viewModel.uiState.value.isPasswordValid)
     }
 
@@ -119,7 +113,7 @@ class SignUpScreenViewModelTest {
     }
 
     @Test
-    fun `onSignUpClick with invalid fields should not call repository`() {
+    fun `onSignUpClick with invalid fields should not attempt sign up`() {
         viewModel.onIntent(SignUpScreenContract.Intent.OnSignUpClick)
 
         coVerify(exactly = 0) { authRepository.signUp(any(), any(), any()) }

--- a/feature/home/src/test/java/rbrthmn/HomeScreenViewModelTest.kt
+++ b/feature/home/src/test/java/rbrthmn/HomeScreenViewModelTest.kt
@@ -17,7 +17,7 @@ class HomeScreenViewModelTest {
     private val viewModel: HomeScreenContract.ViewModel = HomeScreenViewModel()
 
     @Test
-    fun `onDateFilterChange should assign value correctly`() {
+    fun `onDateFilterChange should update the selected month`() {
         viewModel.onIntent(HomeScreenContract.Intent.OnDateFilterChange(VALID_DATE))
 
         assertEquals(VALID_DATE, viewModel.uiState.value.currentDateFilter)

--- a/feature/home/src/test/java/rbrthmn/viewmodels/BalanceCardViewModelTest.kt
+++ b/feature/home/src/test/java/rbrthmn/viewmodels/BalanceCardViewModelTest.kt
@@ -20,121 +20,97 @@ class BalanceCardViewModelTest {
     private val viewModel = BalanceCardViewModel()
 
     @Test
-    fun `onSaveClick with valid input should add new account`() {
-        Locale.setDefault(Locale("pt", "BR"))
-
-        assignValidInputs()
-        val mock = mutableStateOf(true)
-
-        val expectedFormattedValue = formatString(VALID_BALANCE_STRING)
-
-        val newAccount = BalanceCardContract.BankAccountBalanceUiState(
-            name = VALID_STRING,
-            value = expectedFormattedValue,
-            bankName = VALID_STRING
-        )
-        val newAccountList = viewModel.uiState.value.accounts + newAccount
-
-        viewModel.onIntent(Intent.OnSaveClick(mock))
-
-        assertEquals(newAccountList, viewModel.uiState.value.accounts)
-    }
-
-    @Test
-    fun `doOnInit should assign initial values`() {
+    fun `doOnInit should display the total balance and account balances`() {
         viewModel.doOnInit()
-        val expectedList = listOf(
-            br.com.rbrthmn.home.ui.components.balancecard.BalanceCardContract.BankAccountBalanceUiState(
-                name = ACCOUNT_NAME_MOCK,
-                value = formatDouble(ACCOUNT_VALUE_MOCK),
-                bankName = BANK_NAME_MOCK,
-            )
+        val expectedAccount = BalanceCardContract.BankAccountBalanceUiState(
+            name = ACCOUNT_NAME_MOCK,
+            value = formatDouble(ACCOUNT_VALUE_MOCK),
+            bankName = BANK_NAME_MOCK,
         )
 
         assertEquals(formatDouble(TOTAL_BALANCE_MOCK), viewModel.uiState.value.totalBalance)
-        assertEquals(expectedList.first().value, viewModel.uiState.value.accounts.first().value)
-        assertEquals(expectedList.first().name, viewModel.uiState.value.accounts.first().name)
-        assertEquals(
-            expectedList.first().bankName,
-            viewModel.uiState.value.accounts.first().bankName
-        )
+        assertEquals(expectedAccount.value, viewModel.uiState.value.accounts.first().value)
+        assertEquals(expectedAccount.name, viewModel.uiState.value.accounts.first().name)
+        assertEquals(expectedAccount.bankName, viewModel.uiState.value.accounts.first().bankName)
     }
 
     @Test
-    fun `onInitialBalanceChange with empty value should assign correctly`() {
+    fun `onSaveClick with valid input should add the new account and close the dialog`() {
+        Locale.setDefault(Locale("pt", "BR"))
+
+        assignValidInputs()
+        val showDialog = mutableStateOf(true)
+
+        val newAccount = BalanceCardContract.BankAccountBalanceUiState(
+            name = VALID_STRING,
+            value = formatString(VALID_BALANCE_STRING),
+            bankName = VALID_STRING
+        )
+        val expectedAccounts = viewModel.uiState.value.accounts + newAccount
+
+        viewModel.onIntent(Intent.OnSaveClick(showDialog))
+
+        assertEquals(expectedAccounts, viewModel.uiState.value.accounts)
+        assertEquals(false, showDialog.value)
+        assertCleanedInputs()
+    }
+
+    @Test
+    fun `onInitialBalanceChange with empty value should flag balance as required`() {
         viewModel.onIntent(Intent.OnInitialBalanceChange(EMPTY_STRING))
 
         assertEquals(false, viewModel.uiState.value.isNewAccountBalanceValid)
-        assertEquals(EMPTY_STRING, viewModel.uiState.value.newAccountBalance)
     }
 
     @Test
-    fun `onInitialBalanceChange with value should assign correctly`() {
+    fun `onInitialBalanceChange with valid value should accept the balance`() {
         viewModel.onIntent(Intent.OnInitialBalanceChange(VALID_BALANCE_STRING))
 
         assertEquals(true, viewModel.uiState.value.isNewAccountBalanceValid)
-        assertEquals(VALID_BALANCE_STRING, viewModel.uiState.value.newAccountBalance)
     }
 
     @Test
-    fun `onDescriptionChange with empty value should assign correctly`() {
+    fun `onDescriptionChange with empty value should flag description as required`() {
         viewModel.onIntent(Intent.OnDescriptionChange(EMPTY_STRING))
 
         assertEquals(false, viewModel.uiState.value.isNewAccountDescriptionValid)
-        assertEquals(EMPTY_STRING, viewModel.uiState.value.newAccountDescription)
     }
 
     @Test
-    fun `onDescriptionChange with value should assign correctly`() {
+    fun `onDescriptionChange with valid value should accept the description`() {
         viewModel.onIntent(Intent.OnDescriptionChange(VALID_STRING))
 
         assertEquals(true, viewModel.uiState.value.isNewAccountDescriptionValid)
-        assertEquals(VALID_STRING, viewModel.uiState.value.newAccountDescription)
     }
 
     @Test
-    fun `onBankChange with empty value should assign correctly`() {
+    fun `onBankChange with empty bank should flag bank as required`() {
         viewModel.onIntent(Intent.OnBankChange(VALID_ID_STRING, EMPTY_STRING))
 
         assertEquals(false, viewModel.uiState.value.isNewAccountBankValid)
-        assertEquals(EMPTY_STRING, viewModel.uiState.value.newAccountBank)
-        assertEquals(VALID_ID_STRING, viewModel.uiState.value.newAccountBankIcon)
     }
 
     @Test
-    fun `onBankChange with value should assign correctly`() {
-        viewModel.onIntent(Intent.OnBankChange(VALID_ID_STRING, VALID_BALANCE_STRING))
+    fun `onBankChange with a bank selected should accept the bank`() {
+        viewModel.onIntent(Intent.OnBankChange(VALID_ID_STRING, VALID_STRING))
 
         assertEquals(true, viewModel.uiState.value.isNewAccountBankValid)
-        assertEquals(VALID_BALANCE_STRING, viewModel.uiState.value.newAccountBank)
-        assertEquals(VALID_ID_STRING, viewModel.uiState.value.newAccountBankIcon)
     }
 
     @Test
-    fun `cleanNewAccount should assign default values`() {
+    fun `cleanNewAccount should discard the new account form`() {
+        assignValidInputs()
+
         viewModel.onIntent(Intent.CleanNewAccount)
 
         assertCleanedInputs()
     }
 
     @Test
-    fun `onSaveClick with valid input should assign false to dialog`() {
-        assignValidInputs()
-        val mock = mutableStateOf(true)
+    fun `onDateFilterChange should update the selected month`() {
+        viewModel.onIntent(Intent.OnDateFilterChange(VALID_DATE))
 
-        viewModel.onIntent(Intent.OnSaveClick(mock))
-
-        assertEquals(false, mock.value)
-    }
-
-    @Test
-    fun `onSaveClick with valid input should clean inputs`() {
-        assignValidInputs()
-        val mock = mutableStateOf(true)
-
-        viewModel.onIntent(Intent.OnSaveClick(mock))
-
-        assertCleanedInputs()
+        assertEquals(VALID_DATE, viewModel.uiState.value.currentDateFilter)
     }
 
     private fun assertCleanedInputs() {
@@ -153,13 +129,6 @@ class BalanceCardViewModelTest {
             onIntent(Intent.OnDescriptionChange(VALID_STRING))
             onIntent(Intent.OnBankChange(VALID_ID_STRING, VALID_STRING))
         }
-    }
-
-    @Test
-    fun `setDateFilter should assign value correctly`() {
-        viewModel.onIntent(Intent.OnDateFilterChange(VALID_DATE))
-
-        assertEquals(VALID_DATE, viewModel.uiState.value.currentDateFilter)
     }
 
     private companion object {

--- a/feature/home/src/test/java/rbrthmn/viewmodels/CreditCardBillsCardViewModelTest.kt
+++ b/feature/home/src/test/java/rbrthmn/viewmodels/CreditCardBillsCardViewModelTest.kt
@@ -14,38 +14,59 @@ class CreditCardBillsCardViewModelTest {
         CreditCardBillsCardViewModel()
 
     @Test
-    fun `doOnInit should assign initial values`() {
+    fun `doOnInit should display the total bill and per-card bills`() {
         viewModel.doOnInit()
-        val expectedList = listOf(
-            CreditCardBillsCardContract.CreditCardBillUiState(
-                name = CreditCardBillsCardViewModel.Companion.CREDIT_CARD_MOCK,
-                value = formatDouble(CreditCardBillsCardViewModel.Companion.BILL_VALUE_MOCK),
-                dueDay = CreditCardBillsCardViewModel.Companion.DUE_DAY_MOCK,
-                bankName = CreditCardBillsCardViewModel.Companion.BANK_NAME_MOCK,
-            )
+        val expectedBill = CreditCardBillsCardContract.CreditCardBillUiState(
+            name = CreditCardBillsCardViewModel.Companion.CREDIT_CARD_MOCK,
+            value = formatDouble(CreditCardBillsCardViewModel.Companion.BILL_VALUE_MOCK),
+            dueDay = CreditCardBillsCardViewModel.Companion.DUE_DAY_MOCK,
+            bankName = CreditCardBillsCardViewModel.Companion.BANK_NAME_MOCK,
         )
 
         TestCase.assertEquals(
             formatDouble(CreditCardBillsCardViewModel.Companion.TOTAL_BILL_MOCK),
             viewModel.uiState.value.totalBill
         )
-        TestCase.assertEquals(
-            expectedList.first().value,
-            viewModel.uiState.value.bills.first().value
-        )
-        TestCase.assertEquals(expectedList.first().name, viewModel.uiState.value.bills.first().name)
-        TestCase.assertEquals(
-            expectedList.first().bankName,
-            viewModel.uiState.value.bills.first().bankName
-        )
-        TestCase.assertEquals(
-            expectedList.first().dueDay,
-            viewModel.uiState.value.bills.first().dueDay
-        )
+        TestCase.assertEquals(expectedBill.value, viewModel.uiState.value.bills.first().value)
+        TestCase.assertEquals(expectedBill.name, viewModel.uiState.value.bills.first().name)
+        TestCase.assertEquals(expectedBill.bankName, viewModel.uiState.value.bills.first().bankName)
+        TestCase.assertEquals(expectedBill.dueDay, viewModel.uiState.value.bills.first().dueDay)
     }
 
     @Test
-    fun `OnNewCreditCardBillValueChange with empty value should assign correctly`() {
+    fun `onSaveClick with valid input should add the new card and close the dialog`() {
+        assignValidInputs()
+        val showDialog = mutableStateOf(true)
+        val newCard = CreditCardBillsCardContract.CreditCardBillUiState(
+            name = VALID_STRING,
+            value = VALID_BILL_STRING,
+            bankName = VALID_STRING,
+        )
+        val expectedBills = viewModel.uiState.value.bills + newCard
+
+        viewModel.onIntent(CreditCardBillsCardContract.Intent.OnSaveClick(showDialog))
+
+        TestCase.assertEquals(expectedBills, viewModel.uiState.value.bills)
+        TestCase.assertEquals(false, showDialog.value)
+        assertCleanedInputs()
+    }
+
+    @Test
+    fun `onNewCreditCardNameChange with empty value should flag card name as required`() {
+        viewModel.onIntent(CreditCardBillsCardContract.Intent.OnNewCreditCardNameChange(EMPTY_STRING))
+
+        TestCase.assertEquals(false, viewModel.uiState.value.isNewCreditCardNameValid)
+    }
+
+    @Test
+    fun `onNewCreditCardNameChange with valid value should accept the card name`() {
+        viewModel.onIntent(CreditCardBillsCardContract.Intent.OnNewCreditCardNameChange(VALID_STRING))
+
+        TestCase.assertEquals(true, viewModel.uiState.value.isNewCreditCardNameValid)
+    }
+
+    @Test
+    fun `onNewCreditCardBillValueChange with empty value should flag bill value as required`() {
         viewModel.onIntent(
             CreditCardBillsCardContract.Intent.OnNewCreditCardBillValueChange(
                 EMPTY_STRING
@@ -53,11 +74,10 @@ class CreditCardBillsCardViewModelTest {
         )
 
         TestCase.assertEquals(false, viewModel.uiState.value.isNewCreditCardBillValid)
-        TestCase.assertEquals(EMPTY_STRING, viewModel.uiState.value.newCreditCardBill)
     }
 
     @Test
-    fun `OnNewCreditCardBillValueChange with value should assign correctly`() {
+    fun `onNewCreditCardBillValueChange with valid value should accept the bill value`() {
         viewModel.onIntent(
             CreditCardBillsCardContract.Intent.OnNewCreditCardBillValueChange(
                 VALID_BILL_STRING
@@ -65,27 +85,10 @@ class CreditCardBillsCardViewModelTest {
         )
 
         TestCase.assertEquals(true, viewModel.uiState.value.isNewCreditCardBillValid)
-        TestCase.assertEquals(VALID_BILL_STRING, viewModel.uiState.value.newCreditCardBill)
     }
 
     @Test
-    fun `onNewCreditCardNameChange with empty value should assign correctly`() {
-        viewModel.onIntent(CreditCardBillsCardContract.Intent.OnNewCreditCardNameChange(EMPTY_STRING))
-
-        TestCase.assertEquals(false, viewModel.uiState.value.isNewCreditCardNameValid)
-        TestCase.assertEquals(EMPTY_STRING, viewModel.uiState.value.newCreditCardName)
-    }
-
-    @Test
-    fun `onNewCreditCardNameChange with value should assign correctly`() {
-        viewModel.onIntent(CreditCardBillsCardContract.Intent.OnNewCreditCardNameChange(VALID_STRING))
-
-        TestCase.assertEquals(true, viewModel.uiState.value.isNewCreditCardNameValid)
-        TestCase.assertEquals(VALID_STRING, viewModel.uiState.value.newCreditCardName)
-    }
-
-    @Test
-    fun `onBankChange with empty value should assign correctly`() {
+    fun `onBankChange with empty bank should flag bank as required`() {
         viewModel.onIntent(
             CreditCardBillsCardContract.Intent.OnBankChange(
                 VALID_ID_STRING,
@@ -94,26 +97,22 @@ class CreditCardBillsCardViewModelTest {
         )
 
         TestCase.assertEquals(false, viewModel.uiState.value.isNewCreditCardBankNameValid)
-        TestCase.assertEquals(EMPTY_STRING, viewModel.uiState.value.newCreditCardBankName)
-        TestCase.assertEquals(VALID_ID_STRING, viewModel.uiState.value.newCreditCardBankIcon)
     }
 
     @Test
-    fun `onBankChange with value should assign correctly`() {
+    fun `onBankChange with a bank selected should accept the bank`() {
         viewModel.onIntent(
             CreditCardBillsCardContract.Intent.OnBankChange(
                 VALID_ID_STRING,
-                VALID_BILL_STRING
+                VALID_STRING
             )
         )
 
         TestCase.assertEquals(true, viewModel.uiState.value.isNewCreditCardBankNameValid)
-        TestCase.assertEquals(VALID_BILL_STRING, viewModel.uiState.value.newCreditCardBankName)
-        TestCase.assertEquals(VALID_ID_STRING, viewModel.uiState.value.newCreditCardBankIcon)
     }
 
     @Test
-    fun `onNewCreditCardBillDueDayChange with zero value should assign correctly`() {
+    fun `onNewCreditCardBillDueDayChange with zero value should flag due day as required`() {
         viewModel.onIntent(
             CreditCardBillsCardContract.Intent.OnNewCreditCardBillDueDayChange(
                 INVALID_DUE_DAY
@@ -121,11 +120,10 @@ class CreditCardBillsCardViewModelTest {
         )
 
         TestCase.assertEquals(false, viewModel.uiState.value.isNewCreditCardBillDueDayValid)
-        TestCase.assertEquals(INVALID_DUE_DAY, viewModel.uiState.value.newCreditCardBillDueDay)
     }
 
     @Test
-    fun `onNewCreditCardBillDueDayChange with value should assign correctly`() {
+    fun `onNewCreditCardBillDueDayChange with valid day should accept the due day`() {
         viewModel.onIntent(
             CreditCardBillsCardContract.Intent.OnNewCreditCardBillDueDayChange(
                 VALID_DUE_DAY
@@ -133,50 +131,22 @@ class CreditCardBillsCardViewModelTest {
         )
 
         TestCase.assertEquals(true, viewModel.uiState.value.isNewCreditCardBillDueDayValid)
-        TestCase.assertEquals(VALID_DUE_DAY, viewModel.uiState.value.newCreditCardBillDueDay)
     }
 
     @Test
-    fun `cleanNewAccount should assign default values`() {
+    fun `cleanInputs should discard the new card form`() {
+        assignValidInputs()
+
         viewModel.onIntent(CreditCardBillsCardContract.Intent.CleanInputs)
 
         assertCleanedInputs()
     }
 
     @Test
-    fun `onSaveClick with valid input should assign false to dialog`() {
-        assignValidInputs()
-        val mock = mutableStateOf(true)
+    fun `onDateFilterChange should update the selected month`() {
+        viewModel.onIntent(CreditCardBillsCardContract.Intent.OnDateFilterChange(VALID_DATE))
 
-        viewModel.onIntent(CreditCardBillsCardContract.Intent.OnSaveClick(mock))
-
-        TestCase.assertEquals(false, mock.value)
-    }
-
-    @Test
-    fun `onSaveClick with valid input should add new account`() {
-        assignValidInputs()
-        val mock = mutableStateOf(true)
-        val newCard = CreditCardBillsCardContract.CreditCardBillUiState(
-            name = VALID_STRING,
-            value = VALID_BILL_STRING,
-            bankName = VALID_STRING,
-        )
-        val newCardsList = viewModel.uiState.value.bills + newCard
-
-        viewModel.onIntent(CreditCardBillsCardContract.Intent.OnSaveClick(mock))
-
-        TestCase.assertEquals(newCardsList, viewModel.uiState.value.bills)
-    }
-
-    @Test
-    fun `onSaveClick with valid input should clean inputs`() {
-        assignValidInputs()
-        val mock = mutableStateOf(true)
-
-        viewModel.onIntent(CreditCardBillsCardContract.Intent.OnSaveClick(mock))
-
-        assertCleanedInputs()
+        TestCase.assertEquals(VALID_DATE, viewModel.uiState.value.currentDateFilter)
     }
 
     private fun assertCleanedInputs() {
@@ -211,13 +181,6 @@ class CreditCardBillsCardViewModelTest {
                 )
             )
         }
-    }
-
-    @Test
-    fun `setDateFilter should assign value correctly`() {
-        viewModel.onIntent(CreditCardBillsCardContract.Intent.OnDateFilterChange(VALID_DATE))
-
-        TestCase.assertEquals(VALID_DATE, viewModel.uiState.value.currentDateFilter)
     }
 
     private companion object {

--- a/feature/home/src/test/java/rbrthmn/viewmodels/LastMonthDifferenceCardViewModelTest.kt
+++ b/feature/home/src/test/java/rbrthmn/viewmodels/LastMonthDifferenceCardViewModelTest.kt
@@ -13,7 +13,7 @@ class LastMonthDifferenceCardViewModelTest {
         LastMonthDifferenceCardViewModel()
 
     @Test
-    fun `doOnInit should assign initial values`() {
+    fun `doOnInit should display the last month spending difference`() {
         viewModel.doOnInit()
 
         Assert.assertEquals(
@@ -23,7 +23,7 @@ class LastMonthDifferenceCardViewModelTest {
     }
 
     @Test
-    fun `setDateFilter should assign value correctly`() {
+    fun `onDateFilterChange should update the selected month`() {
         viewModel.onIntent(LastMonthDifferenceCardContract.Intent.OnDateFilterChange(VALID_DATE))
 
         TestCase.assertEquals(

--- a/feature/home/src/test/java/rbrthmn/viewmodels/MonthlyLimitCardViewModelTest.kt
+++ b/feature/home/src/test/java/rbrthmn/viewmodels/MonthlyLimitCardViewModelTest.kt
@@ -11,7 +11,7 @@ class MonthlyLimitCardViewModelTest {
     private val viewModel: MonthlyLimitCardContract.ViewModel = MonthlyLimitCardViewModel()
 
     @Test
-    fun `doOnInit should assign initial values`() {
+    fun `doOnInit should display the monthly limit and spending difference`() {
         viewModel.doOnInit()
 
         TestCase.assertEquals(
@@ -25,7 +25,7 @@ class MonthlyLimitCardViewModelTest {
     }
 
     @Test
-    fun `setDateFilter should assign value correctly`() {
+    fun `onDateFilterChange should update the selected month`() {
         viewModel.onIntent(MonthlyLimitCardContract.Intent.OnDateFilterChange(VALID_DATE))
 
         TestCase.assertEquals(

--- a/specs/README.md
+++ b/specs/README.md
@@ -52,13 +52,27 @@ Format: `{PREFIX}-{NNN}` where prefix = abbreviated feature name.
 - `ML` = MonthlyLimitCard
 - `HS` = HomeScreen
 
+### Behaviors state business rules only
+A behavior describes an outcome the user or domain cares about, observable through
+`UiState` or `Effect` — never how the ViewModel gets there.
+
+- Phrase the `description` and `then` as a rule: "should flag balance as required",
+  "should add the new card and close the dialog", "should not attempt sign in"
+- Never "should assign correctly" / "should set field X" — that describes plumbing, not a rule
+- No echo assertions: a field merely mirroring the typed input is not a behavior
+- No implementation details in `then`: internal calls, constants, or field-by-field resets.
+  Interaction with a dependency belongs in a behavior only when it *is* the rule
+  (e.g. "no sign-in attempt made" for an invalid form)
+- One behavior per rule — merge cases that only re-assert the same rule from another angle
+
 ### Test naming
 Test method names must match the behavior `description` field verbatim:
 ```kotlin
 @Test
-fun `doOnInit should collect accounts from repository and update state`() { ... }
+fun `doOnInit should display the total balance and account balances`() { ... }
 // ↑ matches behavior id BC-001 description
 ```
+Test bodies assert only what the behavior's `then` states.
 
 ### Adding a new feature
 1. Copy `specs/_template.yaml` to `specs/feature/{module}/{feature_name}.yaml`

--- a/specs/_template.yaml
+++ b/specs/_template.yaml
@@ -41,27 +41,29 @@ intents:
 # --- Behaviors (acceptance criteria → test cases) ---
 # id format: {PREFIX}-{NNN}
 # description must match @Test fun name verbatim
+# behaviors state business rules only — observable outcomes via UiState/Effects,
+# never plumbing ("should assign correctly") or echo of the typed input
 behaviors:
   - id: XX-001
-    description: "doOnInit should <expected initial state>"
+    description: "doOnInit should <expected user-visible outcome>"
     given: "<precondition>"
     when: "ViewModel initializes"
-    then: "<expected state change>"
+    then: "<business rule outcome>"
 
   - id: XX-002
-    description: "onExampleChange with empty value should mark invalid"
+    description: "onExampleChange with empty value should flag example as required"
     given: "default state"
     when: "OnExampleChange with empty string"
-    then: "isExampleValid = false"
+    then: "example flagged as required (isExampleValid = false)"
 
   - id: XX-003
-    description: "onExampleChange with value should mark valid"
+    description: "onExampleChange with valid value should accept the example"
     given: "default state"
     when: "OnExampleChange with non-empty string"
-    then: "isExampleValid = true, exampleField = given value"
+    then: "example accepted (isExampleValid = true)"
 
   - id: XX-004
-    description: "setDateFilter should update currentDateFilter"
+    description: "onDateFilterChange should update the selected month"
     given: "any state"
     when: "OnDateFilterChange with a date"
-    then: "currentDateFilter = given date"
+    then: "data refers to the selected month"

--- a/specs/feature/auth/password_recovery_screen.yaml
+++ b/specs/feature/auth/password_recovery_screen.yaml
@@ -80,7 +80,7 @@ behaviors:
     description: "onEmailChange with invalid email should mark email invalid"
     given: "default state"
     when: "OnEmailChange with malformed e-mail"
-    then: "email = given value, isEmailValid = false"
+    then: "email flagged as invalid (isEmailValid = false)"
 
   - id: PRS-003
     description: "onVerifyEmailClick with unknown account should show account not found error"
@@ -113,10 +113,10 @@ behaviors:
     then: "Effects ShowPasswordResetSuccess and NavigateToSignIn emitted"
 
   - id: PRS-008
-    description: "onResetPasswordClick with invalid fields should not call repository"
+    description: "onResetPasswordClick with invalid fields should not attempt password reset"
     given: "mismatching confirmation"
     when: "OnResetPasswordClick"
-    then: "repository not called, fields marked invalid"
+    then: "no reset attempt made, confirmation flagged as invalid"
 
   - id: PRS-009
     description: "onBackToSignInClick should emit NavigateToSignIn"

--- a/specs/feature/auth/sign_in_screen.yaml
+++ b/specs/feature/auth/sign_in_screen.yaml
@@ -71,31 +71,31 @@ behaviors:
     description: "onEmailChange with invalid email should mark email invalid"
     given: "default state"
     when: "OnEmailChange with malformed e-mail"
-    then: "email = given value, isEmailValid = false"
+    then: "email flagged as invalid (isEmailValid = false)"
 
   - id: SIS-003
     description: "onEmailChange with valid email should mark email valid"
     given: "default state"
     when: "OnEmailChange with well-formed e-mail"
-    then: "email = given value, isEmailValid = true"
+    then: "email accepted (isEmailValid = true)"
 
   - id: SIS-004
     description: "onPasswordChange with blank value should mark password invalid"
     given: "default state"
     when: "OnPasswordChange with blank string"
-    then: "password = given value, isPasswordValid = false"
+    then: "password flagged as invalid (isPasswordValid = false)"
 
   - id: SIS-005
     description: "onPasswordChange with value should mark password valid"
     given: "default state"
     when: "OnPasswordChange with non-blank string"
-    then: "password = given value, isPasswordValid = true"
+    then: "password accepted (isPasswordValid = true)"
 
   - id: SIS-006
-    description: "onSignInClick with invalid fields should not call repository"
+    description: "onSignInClick with invalid fields should not attempt sign in"
     given: "blank email and password"
     when: "OnSignInClick"
-    then: "repository not called, fields marked invalid"
+    then: "no sign-in attempt made, fields flagged as invalid"
 
   - id: SIS-007
     description: "onSignInClick with valid credentials should emit NavigateToHome"

--- a/specs/feature/auth/sign_up_screen.yaml
+++ b/specs/feature/auth/sign_up_screen.yaml
@@ -87,37 +87,37 @@ behaviors:
     description: "onNameChange with blank value should mark name invalid"
     given: "default state"
     when: "OnNameChange with blank string"
-    then: "name = given value, isNameValid = false"
+    then: "name flagged as invalid (isNameValid = false)"
 
   - id: SUS-003
     description: "onNameChange with value should mark name valid"
     given: "default state"
     when: "OnNameChange with non-blank string"
-    then: "name = given value, isNameValid = true"
+    then: "name accepted (isNameValid = true)"
 
   - id: SUS-004
     description: "onEmailChange with invalid email should mark email invalid"
     given: "default state"
     when: "OnEmailChange with malformed e-mail"
-    then: "email = given value, isEmailValid = false"
+    then: "email flagged as invalid (isEmailValid = false)"
 
   - id: SUS-005
     description: "onEmailChange with valid email should mark email valid"
     given: "default state"
     when: "OnEmailChange with well-formed e-mail"
-    then: "email = given value, isEmailValid = true"
+    then: "email accepted (isEmailValid = true)"
 
   - id: SUS-006
     description: "onPasswordChange with short password should mark password invalid"
     given: "default state"
     when: "OnPasswordChange with fewer than 8 characters"
-    then: "password = given value, isPasswordValid = false"
+    then: "password flagged as invalid (isPasswordValid = false)"
 
   - id: SUS-007
     description: "onPasswordChange with valid password should mark password valid"
     given: "default state"
     when: "OnPasswordChange with 8+ characters"
-    then: "password = given value, isPasswordValid = true"
+    then: "password accepted (isPasswordValid = true)"
 
   - id: SUS-008
     description: "onPasswordConfirmationChange with mismatch should mark confirmation invalid"
@@ -132,10 +132,10 @@ behaviors:
     then: "isPasswordConfirmationValid = true"
 
   - id: SUS-010
-    description: "onSignUpClick with invalid fields should not call repository"
+    description: "onSignUpClick with invalid fields should not attempt sign up"
     given: "blank fields"
     when: "OnSignUpClick"
-    then: "repository not called, fields marked invalid"
+    then: "no sign-up attempt made, fields flagged as invalid"
 
   - id: SUS-011
     description: "onSignUpClick with valid fields should emit NavigateToHome"

--- a/specs/feature/home/balance_card.yaml
+++ b/specs/feature/home/balance_card.yaml
@@ -85,61 +85,61 @@ intents:
 
 behaviors:
   - id: BC-001
-    description: "doOnInit should collect accounts from repository and update state"
-    given: "repository emits AccountsSummary with accounts"
+    description: "doOnInit should display the total balance and account balances"
+    given: "stored accounts exist"
     when: "ViewModel initializes"
-    then: "uiState.totalBalance and accounts populated from repository data"
+    then: "total balance and per-account balances shown to the user"
 
   - id: BC-002
-    description: "onSaveClick with valid input should add new account"
+    description: "onSaveClick with valid input should add the new account and close the dialog"
     given: "valid balance, description, and bank set"
     when: "OnSaveClick"
-    then: "new account appended to accounts list, inputs cleared"
+    then: "new account appears in the account list, form discarded, dialog closed"
 
   - id: BC-003
-    description: "onInitialBalanceChange with empty value should assign correctly"
+    description: "onInitialBalanceChange with empty value should flag balance as required"
     given: "default state"
     when: "OnInitialBalanceChange with empty string"
-    then: "isNewAccountBalanceValid = false, newAccountBalance = empty"
+    then: "balance flagged as required (isNewAccountBalanceValid = false)"
 
   - id: BC-004
-    description: "onInitialBalanceChange with value should assign correctly"
+    description: "onInitialBalanceChange with valid value should accept the balance"
     given: "default state"
     when: "OnInitialBalanceChange with non-empty string"
-    then: "isNewAccountBalanceValid = true, newAccountBalance = given value"
+    then: "balance accepted (isNewAccountBalanceValid = true)"
 
   - id: BC-005
-    description: "onDescriptionChange with empty value should assign correctly"
+    description: "onDescriptionChange with empty value should flag description as required"
     given: "default state"
     when: "OnDescriptionChange with empty string"
-    then: "isNewAccountDescriptionValid = false"
+    then: "description flagged as required (isNewAccountDescriptionValid = false)"
 
   - id: BC-006
-    description: "onDescriptionChange with value should assign correctly"
+    description: "onDescriptionChange with valid value should accept the description"
     given: "default state"
     when: "OnDescriptionChange with non-empty string"
-    then: "isNewAccountDescriptionValid = true, newAccountDescription = given value"
+    then: "description accepted (isNewAccountDescriptionValid = true)"
 
   - id: BC-007
-    description: "onBankChange with empty value should assign correctly"
+    description: "onBankChange with empty bank should flag bank as required"
     given: "default state"
     when: "OnBankChange with empty bank name"
-    then: "isNewAccountBankValid = false"
+    then: "bank flagged as required (isNewAccountBankValid = false)"
 
   - id: BC-008
-    description: "onBankChange with value should assign correctly"
+    description: "onBankChange with a bank selected should accept the bank"
     given: "default state"
     when: "OnBankChange with non-empty bank name"
-    then: "isNewAccountBankValid = true, newAccountBank = given value"
+    then: "bank accepted (isNewAccountBankValid = true)"
 
   - id: BC-009
-    description: "cleanNewAccount should reset all input fields"
+    description: "cleanNewAccount should discard the new account form"
     given: "inputs are set"
     when: "CleanNewAccount"
-    then: "all new account fields reset to defaults"
+    then: "form back to pristine state, no validation errors shown"
 
   - id: BC-010
-    description: "setDateFilter should assign value correctly"
+    description: "onDateFilterChange should update the selected month"
     given: "any state"
     when: "OnDateFilterChange with a date"
-    then: "currentDateFilter = given date"
+    then: "balances refer to the selected month"

--- a/specs/feature/home/credit_card_bills_card.yaml
+++ b/specs/feature/home/credit_card_bills_card.yaml
@@ -97,55 +97,73 @@ intents:
 
 behaviors:
   - id: CCB-001
-    description: "doOnInit should collect credit cards from repository and update state"
-    given: "repository emits list of CreditCardBillItem"
+    description: "doOnInit should display the total bill and per-card bills"
+    given: "stored credit cards exist"
     when: "ViewModel initializes"
-    then: "uiState.totalBill and bills populated from repository data"
+    then: "total bill and per-card bills shown to the user"
 
   - id: CCB-002
-    description: "onSaveClick with valid input should add new card"
+    description: "onSaveClick with valid input should add the new card and close the dialog"
     given: "valid name, bill value, bank, and due day set"
     when: "OnSaveClick"
-    then: "new card appended to bills list, inputs cleared"
+    then: "new card appears in the bills list, form discarded, dialog closed"
 
   - id: CCB-003
-    description: "OnNewCreditCardBillValueChange with empty value should assign correctly"
+    description: "onNewCreditCardNameChange with empty value should flag card name as required"
     given: "default state"
-    when: "OnNewCreditCardBillValueChange with empty string"
-    then: "isNewCreditCardBillValid = false, newCreditCardBill = empty"
+    when: "OnNewCreditCardNameChange with empty string"
+    then: "card name flagged as required (isNewCreditCardNameValid = false)"
 
   - id: CCB-004
-    description: "OnNewCreditCardBillValueChange with value should assign correctly"
+    description: "onNewCreditCardNameChange with valid value should accept the card name"
     given: "default state"
-    when: "OnNewCreditCardBillValueChange with non-empty string"
-    then: "isNewCreditCardBillValid = true, newCreditCardBill = given value"
+    when: "OnNewCreditCardNameChange with non-empty string"
+    then: "card name accepted (isNewCreditCardNameValid = true)"
 
   - id: CCB-005
-    description: "onBankChange with empty value should assign correctly"
+    description: "onNewCreditCardBillValueChange with empty value should flag bill value as required"
     given: "default state"
-    when: "OnBankChange with empty bank name"
-    then: "isNewCreditCardBankNameValid = false"
+    when: "OnNewCreditCardBillValueChange with empty string"
+    then: "bill value flagged as required (isNewCreditCardBillValid = false)"
 
   - id: CCB-006
-    description: "onBankChange with value should assign correctly"
+    description: "onNewCreditCardBillValueChange with valid value should accept the bill value"
     given: "default state"
-    when: "OnBankChange with non-empty bank name"
-    then: "isNewCreditCardBankNameValid = true, newCreditCardBankName = given value"
+    when: "OnNewCreditCardBillValueChange with non-empty string"
+    then: "bill value accepted (isNewCreditCardBillValid = true)"
 
   - id: CCB-007
-    description: "onNewCreditCardBillDueDayChange with zero value should assign correctly"
+    description: "onBankChange with empty bank should flag bank as required"
     given: "default state"
-    when: "OnNewCreditCardBillDueDayChange with 0"
-    then: "isNewCreditCardBillDueDayValid = false, newCreditCardBillDueDay = 0"
+    when: "OnBankChange with empty bank name"
+    then: "bank flagged as required (isNewCreditCardBankNameValid = false)"
 
   - id: CCB-008
-    description: "onNewCreditCardBillDueDayChange with value should assign correctly"
+    description: "onBankChange with a bank selected should accept the bank"
     given: "default state"
-    when: "OnNewCreditCardBillDueDayChange with non-zero day"
-    then: "isNewCreditCardBillDueDayValid = true, newCreditCardBillDueDay = given day"
+    when: "OnBankChange with non-empty bank name"
+    then: "bank accepted (isNewCreditCardBankNameValid = true)"
 
   - id: CCB-009
-    description: "setDateFilter should assign value correctly"
+    description: "onNewCreditCardBillDueDayChange with zero value should flag due day as required"
+    given: "default state"
+    when: "OnNewCreditCardBillDueDayChange with 0"
+    then: "due day flagged as required (isNewCreditCardBillDueDayValid = false)"
+
+  - id: CCB-010
+    description: "onNewCreditCardBillDueDayChange with valid day should accept the due day"
+    given: "default state"
+    when: "OnNewCreditCardBillDueDayChange with non-zero day"
+    then: "due day accepted (isNewCreditCardBillDueDayValid = true)"
+
+  - id: CCB-011
+    description: "cleanInputs should discard the new card form"
+    given: "inputs are set"
+    when: "CleanInputs"
+    then: "form back to pristine state, no validation errors shown"
+
+  - id: CCB-012
+    description: "onDateFilterChange should update the selected month"
     given: "any state"
     when: "OnDateFilterChange with a date"
-    then: "currentDateFilter = given date"
+    then: "bills refer to the selected month"

--- a/specs/feature/home/home_screen.yaml
+++ b/specs/feature/home/home_screen.yaml
@@ -23,7 +23,7 @@ intents:
 
 behaviors:
   - id: HS-001
-    description: "setDateFilter should update currentDateFilter"
+    description: "onDateFilterChange should update the selected month"
     given: "default state"
     when: "OnDateFilterChange with a date"
-    then: "currentDateFilter = given date"
+    then: "child cards receive the selected month"

--- a/specs/feature/home/last_month_difference_card.yaml
+++ b/specs/feature/home/last_month_difference_card.yaml
@@ -26,13 +26,13 @@ intents:
 
 behaviors:
   - id: LMD-001
-    description: "doOnInit should collect difference from repository and update state"
-    given: "repository emits a difference value"
+    description: "doOnInit should display the last month spending difference"
+    given: "spending data for the previous month exists"
     when: "ViewModel initializes"
-    then: "uiState.valueOfLastMonth populated from repository data"
+    then: "last month difference shown to the user"
 
   - id: LMD-002
-    description: "setDateFilter should assign value correctly"
+    description: "onDateFilterChange should update the selected month"
     given: "any state"
     when: "OnDateFilterChange with a date"
-    then: "currentDateFilter = given date"
+    then: "difference refers to the selected month"

--- a/specs/feature/home/monthly_limit_card.yaml
+++ b/specs/feature/home/monthly_limit_card.yaml
@@ -29,19 +29,13 @@ intents:
 
 behaviors:
   - id: ML-001
-    description: "doOnInit should set hardcoded monthLimit"
-    given: "any state"
+    description: "doOnInit should display the monthly limit and spending difference"
+    given: "a monthly limit is configured and spending data exists"
     when: "ViewModel initializes"
-    then: "uiState.monthLimit = formatted MONTH_LIMIT constant"
+    then: "monthly limit and spending difference shown to the user"
 
   - id: ML-002
-    description: "doOnInit should collect monthly spent from repository and update monthDifference"
-    given: "repository emits monthly spent value"
-    when: "ViewModel initializes"
-    then: "uiState.monthDifference populated from repository data"
-
-  - id: ML-003
-    description: "setDateFilter should assign value correctly"
+    description: "onDateFilterChange should update the selected month"
     given: "any state"
     when: "OnDateFilterChange with a date"
-    then: "currentDateFilter = given date"
+    then: "spending refers to the selected month"

--- a/specs/feature/settings/settings_screen.yaml
+++ b/specs/feature/settings/settings_screen.yaml
@@ -84,4 +84,4 @@ behaviors:
     description: "onConfirmLogout should sign out and emit NavigateToSignIn"
     given: "logout dialog open"
     when: "OnConfirmLogout"
-    then: "repository signOut called, showLogoutDialog = false, Effect NavigateToSignIn emitted"
+    then: "session ended, showLogoutDialog = false, Effect NavigateToSignIn emitted"


### PR DESCRIPTION
## Summary
- Spec behaviors described ViewModel plumbing (field assignments, repository calls) instead of outcomes the user or domain cares about
- Rephrases all behavior `description` and `then` clauses as observable business rules and documents the convention in `specs/README.md` and `specs/_template.yaml`
- Aligns tests: names match new descriptions verbatim, echo assertions dropped, redundant tests merged

## Changes
- `specs/README.md` — new "Behaviors state business rules only" convention section
- `specs/_template.yaml` — examples rewritten as rule-style behaviors
- `specs/feature/**` (9 files) — behaviors rephrased; `credit_card_bills_card.yaml` expanded to CCB-001..012 (adds card-name validation and cleanInputs behaviors the spec was missing); `monthly_limit_card.yaml` ML-001+ML-002 merged
- `feature/auth`, `feature/home` tests — renamed to match specs, echo asserts removed, 3 onSaveClick tests merged into 1 per card

## Test plan
- [x] `./gradlew :feature:auth:testDebugUnitTest :feature:home:testDebugUnitTest` — BUILD SUCCESSFUL
- [x] Every behavior id has a test whose name matches its description verbatim

## Linked issue
Closes #75

> Stacked on `feature/73-google-auth-firebase` — merge #73's branch first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)