### PR TITLE
fix(ui): remove launcher activity from core:ui library manifest

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,7 +87,7 @@ dependencies {
     implementation(project(":data:misc"))
 
     // JUnit KTX
-    implementation(libs.androidx.junit.ktx)
+    androidTestImplementation(libs.androidx.junit.ktx)
 
     // Testes
     testImplementation(project(":core:test"))

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -35,6 +35,15 @@ android {
     buildFeatures {
         compose = true
     }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            excludes += "META-INF/LICENSE*"
+            excludes += "META-INF/NOTICE*"
+            excludes += "META-INF/junit-platform.properties"
+            excludes += "META-INF/junit-jupiter-*.properties"
+        }
+    }
 }
 
 dependencies {

--- a/core/ui/src/main/AndroidManifest.xml
+++ b/core/ui/src/main/AndroidManifest.xml
@@ -1,15 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <application>
-        <activity
-            android:name="androidx.activity.ComponentActivity"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
-    </application>
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
## What was broken
Installing the app created two launcher icons. The second opened a blank activity instead of the app.

## Root cause
`core/ui/src/main/AndroidManifest.xml` declared `androidx.activity.ComponentActivity` with a MAIN/LAUNCHER intent filter. As a library manifest, it gets folded into the app manifest by the manifest merger, producing a second icon alongside `MainActivity`.

While verifying the fix, also found `:app` shipped test libraries in the production APK: `androidx.test.ext:junit-ktx` was declared `implementation` instead of `androidTestImplementation`, pulling in extra activities and permissions (`WAKE_LOCK`, `RECEIVE_BOOT_COMPLETED`).

## Fix
- `core/ui/src/main/AndroidManifest.xml` — stripped to a bare `<manifest/>`; instrumented tests still get `ComponentActivity` from `ui-test-manifest`, already exposed as `api` by `core:test`
- `core/ui/build.gradle.kts` — added the standard packaging exclusions (its androidTest APK failed to merge duplicate `META-INF/LICENSE.md` files from JUnit Jupiter without them — pre-existing, unmasked once the manifest was fixed)
- `app/build.gradle.kts` — moved `junit-ktx` to `androidTestImplementation`

## Test plan
- [x] `:app:assembleDebug` — BUILD SUCCESSFUL
- [x] `:core:ui:assembleDebugAndroidTest` and `:app:assembleDebugAndroidTest` — BUILD SUCCESSFUL
- [x] Merged app manifest parsed — exactly one MAIN+LAUNCHER activity (`br.com.rbrthmn.ui.MainActivity`)
- [x] Merged app manifest contains no `androidx.test` entries

## Linked issue
Closes #77

> Stacked on `feature/73-google-auth-firebase` — merge #73's branch first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)